### PR TITLE
feat: Add $/metrics endpoint with some basic prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <ver.aws-s3>1.11.734</ver.aws-s3>
     <ver.s3mock>0.2.5</ver.s3mock>
     <ver.awaitility>3.1.1</ver.awaitility>
+    <ver.micrometer>1.2.1</ver.micrometer>
   </properties>
   
   <modules>
@@ -286,6 +287,18 @@
             <artifactId>aws-java-sdk-s3</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${ver.micrometer}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-prometheus</artifactId>
+          <version>${ver.micrometer}</version>
       </dependency>
 
     </dependencies>

--- a/rdf-delta-base/src/main/java/org/seaborne/delta/DeltaConst.java
+++ b/rdf-delta-base/src/main/java/org/seaborne/delta/DeltaConst.java
@@ -43,6 +43,7 @@ public class DeltaConst {
 
     public static final String EP_InitData     = "init-data";
     public static final String EP_Ping         = "$/ping";
+    public static final String EP_Metrics      = "$/metrics";
     public static final String EP_RPC          = "$/rpc";
 
     // RPC calls - operation names.

--- a/rdf-delta-server-http/src/main/java/org/seaborne/delta/server/http/PatchLogServer.java
+++ b/rdf-delta-server-http/src/main/java/org/seaborne/delta/server/http/PatchLogServer.java
@@ -95,6 +95,8 @@ public /*package*/ class PatchLogServer {
 
         addServlet(handler, "/"+DeltaConst.EP_Ping, new S_Ping());  //-- See also the "ping" DRPC.
 
+        addServlet(handler, "/"+DeltaConst.EP_Metrics, new S_Metrics());
+
         // Initial data. "/init-data?datasource=..."
         addServlet(handler, "/"+DeltaConst.EP_InitData, new S_Data(this.deltaLink));
 

--- a/rdf-delta-server-http/src/main/java/org/seaborne/delta/server/http/S_Metrics.java
+++ b/rdf-delta-server-http/src/main/java/org/seaborne/delta/server/http/S_Metrics.java
@@ -1,0 +1,100 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  See the NOTICE file distributed with this work for additional
+ *  information regarding copyright ownership.
+ */
+
+package org.seaborne.delta.server.http;
+
+import java.io.IOException ;
+import java.io.File ;
+
+import javax.servlet.ServletOutputStream ;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest ;
+import javax.servlet.http.HttpServletResponse ;
+
+import org.apache.jena.riot.WebContent ;
+import org.apache.jena.riot.web.HttpNames ;
+import org.apache.jena.web.HttpSC ;
+import org.seaborne.delta.Delta ;
+import org.seaborne.delta.DeltaConst ;
+import org.slf4j.Logger ;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.DiskSpaceMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+
+
+/** Respond with prometheus metrics */
+public class S_Metrics extends HttpServlet {
+    static private Logger LOG = Delta.DELTA_LOG ;
+    private PrometheusMeterRegistry meterRegistry;
+
+    public S_Metrics() {
+        meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        meterRegistry.config().commonTags("application", DeltaConst.pDeltaStore);
+
+        new FileDescriptorMetrics().bindTo(meterRegistry);
+        new ProcessorMetrics().bindTo(meterRegistry);
+        new ClassLoaderMetrics().bindTo(meterRegistry);
+        new UptimeMetrics().bindTo(meterRegistry);
+        for (File root : File.listRoots()) {
+            new DiskSpaceMetrics(root).bindTo(meterRegistry);
+        }
+        // Has a warning about resource closing.
+        @SuppressWarnings("resource")
+        JvmGcMetrics x = new JvmGcMetrics();
+        x.bindTo(meterRegistry);
+        new JvmMemoryMetrics().bindTo(meterRegistry);
+        new JvmThreadMetrics().bindTo(meterRegistry);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        text(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        text(req, resp);
+    }
+
+    protected void metrics(ServletOutputStream out) throws IOException {
+	out.write(meterRegistry.scrape().getBytes());
+    }
+
+    private void text(HttpServletRequest req, HttpServletResponse resp) {
+        try {
+            resp.setHeader(HttpNames.hContentType,  WebContent.contentTypeTextPlain);
+            resp.setStatus(HttpSC.OK_200);
+            try(ServletOutputStream out = resp.getOutputStream(); ) {
+                metrics(out);
+            }
+        } catch (IOException ex) {
+            LOG.warn("text out: IOException", ex);
+            try {
+                resp.sendError(HttpSC.INTERNAL_SERVER_ERROR_500, "Internal server error");
+            } catch (IOException ex2) {}
+        }
+    }
+}


### PR DESCRIPTION
This sets up some basic JVM metrics in a prometheus-compatible format. The
`$/metrics` endpoint mimics the same pattern as in fuseki and this set of
stats is the same as in fuseki. There are currently no request metrics
added, which would be a nice addition.