### PR TITLE
added jena-text dependency to allow use of full text indexing with fuseki servers

### DIFF
--- a/docs/delta-fuseki-config.md
+++ b/docs/delta-fuseki-config.md
@@ -20,7 +20,6 @@ PREFIX delta:   <http://jena.apache.org/rdf-delta#>
 ## A Fuseki service offering all SPARQL protocols.
 <#service1> rdf:type fuseki:Service ;
     fuseki:name                        "ds" ;
-    fuseki:endpoint [ fuskei:operation 
     fuseki:serviceQuery                "query" ;
     fuseki:serviceUpdate               "update" ;
     fuseki:serviceUpload               "upload" ;

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-text</artifactId>
+        <version>${ver.jena}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
         <version>${ver.jetty}</version>

--- a/rdf-delta-cmds/pom.xml
+++ b/rdf-delta-cmds/pom.xml
@@ -99,7 +99,7 @@
     <!-- Only for the patch service -->
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
-      <artifactId>rdf-delta-fuseki</artifactId>
+      <artifactId>rdf-delta-fuseki-server</artifactId>
       <version>0.9.1-SNAPSHOT</version>
     </dependency>
 

--- a/rdf-delta-fuseki-server/pom.xml
+++ b/rdf-delta-fuseki-server/pom.xml
@@ -58,6 +58,13 @@
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
 
+    <!-- Included so that full text search will be possible -->
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-text</artifactId>
+    </dependency>
+
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
I simply added `jena-text` as a dependency of `rdf-delta-fuseki` so that it will be available in the case that someone wants to enable full text search while using rdf-delta with a fuseki server.