### PR TITLE
jetty option is ignored when using dcmd to run patch server

### DIFF
--- a/rdf-delta-cmds/src/main/java/delta/server/ServerBuildLib.java
+++ b/rdf-delta-cmds/src/main/java/delta/server/ServerBuildLib.java
@@ -68,22 +68,22 @@ public /*package*/ class ServerBuildLib {
         switch (deltaServerConfig.provider) {
             case FILE :
                 psp = installProvider(new PatchStoreProviderFile());
-                localServerConfig = LocalServers.configFile(deltaServerConfig.fileBase);
+                localServerConfig = LocalServers.configFile(deltaServerConfig.fileBase, deltaServerConfig.jettyConf);
                 providerLabel = "file["+deltaServerConfig.fileBase+"]";
                 break;
             case ROCKS :
                 psp = installProvider(new PatchStoreProviderRocks());
-                localServerConfig = LocalServers.configRDB(deltaServerConfig.fileBase);
+                localServerConfig = LocalServers.configRDB(deltaServerConfig.fileBase, deltaServerConfig.jettyConf);
                 providerLabel = "rdb["+deltaServerConfig.fileBase+"]";
                 break;
             case LOCAL:
                 psp = installProvider(new PatchStoreProviderAnyLocal());
-                localServerConfig = LocalServers.configLocal(deltaServerConfig.fileBase);
+                localServerConfig = LocalServers.configLocal(deltaServerConfig.fileBase, deltaServerConfig.jettyConf);
                 providerLabel = "local["+deltaServerConfig.fileBase+"]";
                 break;
             case MEM :
                 psp = installProvider(new PatchStoreProviderMem());
-                localServerConfig = LocalServers.configMem();
+                localServerConfig = LocalServers.configMem(deltaServerConfig.jettyConf);
                 providerLabel = "mem";
                 break;
             case ZKZK :
@@ -132,7 +132,7 @@ public /*package*/ class ServerBuildLib {
         if ( config.zkConnectionString == null )
             throw new DeltaConfigException("No connection string for ZooKeeper");
         // If zk+S3, there isn't a provider name set yet.
-        LocalServerConfig localServerConfig = LocalServers.configZk(config.zkConnectionString);
+        LocalServerConfig localServerConfig = LocalServers.configZk(config.zkConnectionString, config.jettyConf);
         return localServerConfig;
     }
 
@@ -197,7 +197,7 @@ public /*package*/ class ServerBuildLib {
     }
 
     // --> DeltaServer.start()
-    private static DeltaServer buildServer(int port, Supplier<LocalServerConfig> startup) {
+    private static DeltaServer buildServer(Integer port, Supplier<LocalServerConfig> startup) {
         LocalServerConfig localServerConfig = startup.get();
         // Scope for further properties.
         Properties properties = new Properties();

--- a/rdf-delta-cmds/src/test/java/org/seaborne/delta/cmds/CmdTestLib.java
+++ b/rdf-delta-cmds/src/test/java/org/seaborne/delta/cmds/CmdTestLib.java
@@ -45,8 +45,16 @@ public class CmdTestLib {
     }
 
     public static String server(String... args) {
-        int port = WebLib.choosePort();
-        String[] serverArgs = {"--port="+port};
+        return server(args, WebLib.choosePort());
+    }
+
+    public static String serverJettyConfig(String... args) {
+        return server(args, null);
+    }
+
+    private static String server(String[] args, Integer port) {
+        int finalPort = (port == null ? 1068 : port);
+        String[] serverArgs = (port == null ? new String[0] : new String[] {"--port="+finalPort});
 
         String[] cmdLine = new String[args.length+serverArgs.length];
         System.arraycopy(args, 0, cmdLine, serverArgs.length, args.length);
@@ -56,7 +64,7 @@ public class CmdTestLib {
         } catch (BindException e) {
             throw new RuntimeException(e);
         }
-        return "http://localhost:"+port+"/";
+        return "http://localhost:"+finalPort+"/";
     }
 
 }

--- a/rdf-delta-cmds/src/test/java/org/seaborne/delta/cmds/TestCmdServer.java
+++ b/rdf-delta-cmds/src/test/java/org/seaborne/delta/cmds/TestCmdServer.java
@@ -74,6 +74,12 @@ public class TestCmdServer {
         serverAndVerify(args);
     }
 
+    @Test public void server5_jettyConfig() {
+        String[] args = {"--jetty=testing/jetty.xml", "--mem"};
+        String serverURL = CmdTestLib.serverJettyConfig(args);
+        verifyServer(serverURL);
+    }
+
     public static void serverAndVerify(String[] args) {
         String serverURL = CmdTestLib.server(args);
         verifyServer(serverURL);

--- a/rdf-delta-cmds/src/test/java/org/seaborne/delta/cmds/TestLocalServerCmdSetup.java
+++ b/rdf-delta-cmds/src/test/java/org/seaborne/delta/cmds/TestLocalServerCmdSetup.java
@@ -63,6 +63,12 @@ public class TestLocalServerCmdSetup {
         assertEquals(Provider.FILE, server.getPatchStore().getProvider().getType());
     }
 
+    @Test public void localServer3_jettyConfig() {
+        String[] args = {"--jetty=testing/jetty.xml", "--mem"};
+        LocalServer server = buildLocalServer(args);
+        assertEquals("testing/jetty.xml", server.getConfig().getJettyConfigFile());
+    }
+
     /** The essential steps from DeltaServerCmd/ServerBuildLib to build a {@link LocalServer} */
     private LocalServer buildLocalServer(String[] args) {
         DeltaServerConfig deltaServerConfig = DeltaServerCmd.config(args);

--- a/rdf-delta-cmds/testing/jetty.xml
+++ b/rdf-delta-cmds/testing/jetty.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <!-- Mininal jetty.xml to run on a specific port, locked to localhost -->
+    <Call name="addConnector">
+        <Arg>
+            <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
+                <Arg name="server"><Ref refid="Server" /></Arg>
+                <Arg name="factories">
+                    <Array type="org.eclipse.jetty.server.ConnectionFactory">
+                        <Item>
+                            <New class="org.eclipse.jetty.server.HttpConnectionFactory"/>
+                        </Item>
+                    </Array>
+                </Arg>
+                <Set name="host">localhost</Set>
+                <Set name="port">1068</Set>
+            </New>
+        </Arg>
+    </Call>
+</Configure>

--- a/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/LocalServerConfig.java
+++ b/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/LocalServerConfig.java
@@ -127,6 +127,7 @@ public class LocalServerConfig {
         public Builder(LocalServerConfig other) {
             this.configFile = other.configFile;
             this.logProvider = other.logProvider;
+            this.jettyConfigFile = other.jettyConf;
             copyPropertiesInto(other.properties, this.properties);
         }
 

--- a/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/LocalServers.java
+++ b/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/LocalServers.java
@@ -33,32 +33,56 @@ public class LocalServers {
 
     /** {@link LocalServerConfig} for a {@link LocalServer} with a local storage patch store. */
     public static LocalServerConfig configLocal(String directory) {
+        return configLocal(directory, null);
+    }
+
+    /** {@link LocalServerConfig} for a {@link LocalServer} with a local storage patch store. */
+    public static LocalServerConfig configLocal(String directory, String jettyConf) {
         return LocalServerConfig.create()
             .setProperty(DeltaConst.pDeltaStore, directory)
             .setLogProvider(Provider.LOCAL)
+            .jettyConfigFile(jettyConf)
             .build();
     }
 
     /** {@link LocalServerConfig} for a {@link LocalServer} with a file-based patch store. */
     public static LocalServerConfig configFile(String directory) {
+        return configFile(directory, null);
+    }
+
+    /** {@link LocalServerConfig} for a {@link LocalServer} with a file-based patch store. */
+    public static LocalServerConfig configFile(String directory, String jettyConf) {
         return LocalServerConfig.create()
             .setProperty(DeltaConst.pDeltaStore, directory)
             .setLogProvider(Provider.FILE)
+            .jettyConfigFile(jettyConf)
             .build();
     }
 
     /** {@link LocalServerConfig} for a {@link LocalServer} with a RockDB-based patch store. */
     public static LocalServerConfig configRDB(String directory) {
+        return configRDB(directory, null);
+    }
+
+    /** {@link LocalServerConfig} for a {@link LocalServer} with a RockDB-based patch store. */
+    public static LocalServerConfig configRDB(String directory, String jettyConf) {
         return LocalServerConfig.create()
             .setProperty(DeltaConst.pDeltaStore, directory)
             .setLogProvider(Provider.ROCKS)
+            .jettyConfigFile(jettyConf)
             .build();
     }
 
     /** {@link LocalServerConfig} for a {@link LocalServer} with a memory-based patch store. */
     public static LocalServerConfig configMem() {
+        return configMem(null);
+    }
+
+    /** {@link LocalServerConfig} for a {@link LocalServer} with a memory-based patch store. */
+    public static LocalServerConfig configMem(String jettyConf) {
         return LocalServerConfig.create()
             .setLogProvider(Provider.MEM)
+            .jettyConfigFile(jettyConf)
             .build();
     }
 
@@ -67,8 +91,17 @@ public class LocalServers {
      * and zookeeper-based index patch store.
      */
     public static LocalServerConfig configZk(String connectionString) {
+        return configZk(connectionString, null);
+    }
+
+    /**
+     * {@link LocalServerConfig} for a {@link LocalServer} with a zookeeper-based index
+     * and zookeeper-based index patch store.
+     */
+    public static LocalServerConfig configZk(String connectionString, String jettyConf) {
         LocalServerConfig.Builder builder = LocalServerConfig.create()
-            .setLogProvider(Provider.ZKZK);
+            .setLogProvider(Provider.ZKZK)
+            .jettyConfigFile(jettyConf);
         if ( connectionString != null )
             builder.setProperty(DeltaConst.pDeltaZk, connectionString);
         return builder.build();


### PR DESCRIPTION
Running something like the following, will produce an error:

```shell
$ dcmd server --jetty=jetty.xml
```

Error thrown:
```
Exception in thread "main" java.lang.NullPointerException
    at delta.server.ServerBuildLib.build(ServerBuildLib.java:58)
    at delta.server.DeltaServerCmd.server(DeltaServerCmd.java:130)
    at delta.server.DeltaServerCmd.main(DeltaServerCmd.java:91)
    at org.seaborne.delta.cmds.dcmd.main(dcmd.java:137)
    at dcmd.main(dcmd.java:38)
```

This is caused because a primitive `int` is expected when calling `ServerBuildLib.build` but when a jetty config file is used, the `int` value will always be `null`. On top of that, the jetty config file is never actually set to be used by the resulting `LocalServerConfig` generated in `ServerBuildLib.setupLocalServerConfig`. These two issues needed to be corrected in order for the `--jetty` option to work correctly.
