### PR TITLE
Fixed javadoc and other errors discovered by IntelliJ IDEA.

### DIFF
--- a/rdf-delta-base/pom.xml
+++ b/rdf-delta-base/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-fuseki-main</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/rdf-delta-base/src/main/java/org/seaborne/delta/lib/SystemInfo.java
+++ b/rdf-delta-base/src/main/java/org/seaborne/delta/lib/SystemInfo.java
@@ -28,7 +28,7 @@ public class SystemInfo {
 
     /**
      * Object which holds metadata specified within
-     * {@link Fuseki#metadataLocation}
+     * {@link org.apache.jena.fuseki.Fuseki}#metadataLocation.
      */
     static private Metadata metadata                     = initMetadata();
 

--- a/rdf-delta-client/src/main/java/org/seaborne/delta/client/LogLock.java
+++ b/rdf-delta-client/src/main/java/org/seaborne/delta/client/LogLock.java
@@ -207,7 +207,7 @@ public class LogLock {
      * Number of attempts watching for the session to change or ticks not to change.
      *
      * This is the inner loop.
-     * Related: retry frequency in {@link LogLockMgr#REFRESH_MS}.
+     * @see LogLockMgr
      */
     private static int LOCK_SAME_TICKS_RETRIES          = 60;
 

--- a/rdf-delta-examples/Tutorial/zk-example/single/log4j.properties
+++ b/rdf-delta-examples/Tutorial/zk-example/single/log4j.properties
@@ -8,7 +8,6 @@ log4j.appender.stdlog.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20c :: %m%n
 # Zookeeper
 log4j.logger.org.apache.zookeeper           = INFO
 log4j.logger.org.apache.zookeeper.server.NIOServerCnxn = ERROR
-log4j.logger.org.apache.zookeeper.server.NIOServerCnxn = ERROR
 log4j.logger.org.apache.zookeeper.jmx.ManagedUtil      = WARN
 log4j.logger.org.apache.zookeeper.server.quorum.QuorumPeerMain = ERROR
 

--- a/rdf-delta-server-http/src/main/java/org/seaborne/delta/server/http/DeltaServlet.java
+++ b/rdf-delta-server-http/src/main/java/org/seaborne/delta/server/http/DeltaServlet.java
@@ -75,7 +75,7 @@ public abstract class DeltaServlet extends HttpServlet {
 
     /**
      * {@code HttpServlet.service} : add PATCH, add protection for exceptions.
-     * ({@link doCommon} should handle these).
+     * ({@link #doCommon(HttpServletRequest, HttpServletResponse)} should handle these).
      */
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) {

--- a/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/PatchStore.java
+++ b/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/PatchStore.java
@@ -300,7 +300,7 @@ public abstract class PatchStore {
 
     /** Create and properly register a new {@link PatchLog}.
      *  Call this to add new patch logs including remote changes.
-     *  This method calls {@link #create} provided by the subclass.
+     *  This method calls {@link #newPatchLog(DataSourceDescription)} provided by the subclass.
      *  This method called by PatchStoreZk when a new log appears.
      */
     final

--- a/rdf-patch/src/main/java/org/seaborne/patch/filelog/rotate/FileMgr.java
+++ b/rdf-patch/src/main/java/org/seaborne/patch/filelog/rotate/FileMgr.java
@@ -112,7 +112,7 @@ public class FileMgr {
         return filenames;
     }
 
-    /** Create a {@link FileName} */
+    /** Create a {@link Filename} */
     private static Filename fromPath(Path directory, Path filepath, Pattern pattern) {
         filepath = directory.resolve(filepath).getFileName();
         directory = directory.resolve(filepath).getParent();

--- a/rdf-patch/src/main/java/org/seaborne/patch/filelog/rotate/RollerTimestamp.java
+++ b/rdf-patch/src/main/java/org/seaborne/patch/filelog/rotate/RollerTimestamp.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Filename policy where files are "filebase-yyyy-mm-dd_hh-mm-ss"
- *  and do not rollover automatically, only when prompted via {@link #forceRollover}.
+ *  and do not rollover automatically, only when prompted via {@link #rotate()}.
  */
 class RollerTimestamp implements Roller {
     private final static Logger LOG = LoggerFactory.getLogger(RollerTimestamp.class);


### PR DESCRIPTION
This Pull Request fixes several small issues in javadocs and a duplicate entry in a properties file. This is being done in a discrete Pull Request as part of a series of PRs that will clean up numerous issues in the code that are surfaced by IntelliJ IDEA's inspections. The goal is to tidy up the codebase to make it easier to improve and maintain in the long run since outdated documentation and dead code make it much more difficult to reason about what the code is doing.