### PR TITLE
Sync updates

### DIFF
--- a/rdf-delta-base/src/main/java/org/seaborne/delta/Version.java
+++ b/rdf-delta-base/src/main/java/org/seaborne/delta/Version.java
@@ -115,8 +115,6 @@ public class Version implements Comparable<Version> {
         return Version.create(version+1);
     }
 
-
-
     public Version dec() {
         if ( this == INIT || this == UNSET )
             throw new DeltaException("Attempt to get version before a non-version number: "+this);
@@ -141,6 +139,10 @@ public class Version implements Comparable<Version> {
     public boolean isValid() {
         //return this != Version.UNSET && this != Version.INIT ;
         return version != Version.UNSET.value() && version != Version.INIT.value() ;
+    }
+
+    public boolean isUnset() {
+        return version == Version.UNSET.value();
     }
 
     public JsonValue asJson() {

--- a/rdf-delta-client/src/main/java/org/seaborne/delta/client/DeltaConnection.java
+++ b/rdf-delta-client/src/main/java/org/seaborne/delta/client/DeltaConnection.java
@@ -307,7 +307,6 @@ public class DeltaConnection implements AutoCloseable {
             // Run (almost) immediately and then every 5 minutes
             scheduledExecutionService.scheduleAtFixedRate(this::asyncOneSync, 0, 5*60, TimeUnit.SECONDS);
         }
-
     }
 
     /*package*/ void finish() {
@@ -397,28 +396,39 @@ public class DeltaConnection implements AutoCloseable {
         }
 
         Version localVer = getLocalVersion();
+        if (  localVer.isUnset() ) {
+            FmtLog.warn(LOG, "[%s] Local version is UNSET : sync to %s not done", datasourceId, version);
+            return;
+        }
 
         if ( localVer.value() > version.value() )
             FmtLog.info(LOG, "[%s] Local version ahead of remote : [local=%d, remote=%d]", datasourceId, getLocalVersion(), getRemoteVersionCached());
         if ( localVer.value() >= version.value() )
             return;
-        // bring up-to-date.
-
-        FmtLog.info(LOG, "Sync: Versions [%s, %s]", localVer, version);
-        playPatches(localVer.value()+1, version.value()) ;
+        // localVer is not UNSET so next version to fetch is +1 (INIT is version 0)
+        FmtLog.info(LOG, "[%s:%s] Sync: Versions [%s, %s]", datasourceId, datasourceName, localVer, version);
+        playPatches(localVer, localVer.value()+1, version.value()) ;
         //FmtLog.info(LOG, "Now: Versions [%d, %d]", getLocalVersion(), remoteVer);
     }
 
     /** Play the patches (range is inclusive at both ends) */
-    private void playPatches(long firstPatchVer, long lastPatchVer) {
-        Pair<Version, Node> p = play(datasourceId, base, target, dLink, firstPatchVer, lastPatchVer);
+    private void playPatches(Version currentVersion, long firstPatchVer, long lastPatchVer) {
+        Pair<Version, Node> p = play(datasourceId, base, target, dLink, currentVersion, firstPatchVer, lastPatchVer);
+        if ( p == null )
+            // Didn't make progress for some reason.
+            return;
         Version patchLastVersion = p.car();
         Node patchLastIdNode = p.cdr();
+        if ( patchLastIdNode == null || patchLastVersion.equals(currentVersion) )
+            // No progress.
+            return;
         setLocalState(patchLastVersion, patchLastIdNode);
     }
 
     /** Play patches, return details of the the last successfully applied one */
-    private static Pair<Version, Node> play(Id datasourceId, DatasetGraph base, RDFChanges target, DeltaLink dLink, long minVersion, long maxVersion) {
+    private static Pair<Version, Node> play(Id datasourceId, DatasetGraph base, RDFChanges target, DeltaLink dLink,
+                                            Version currentVersion,
+                                            long minVersion, long maxVersion) {
         // [Delta] replace with a one-shot "get all patches" operation.
         //FmtLog.debug(LOG, "Patch range [%d, %d]", minVersion, maxVersion);
 
@@ -429,7 +439,7 @@ public class DeltaConnection implements AutoCloseable {
         try {
             return Txn.calculateWrite(base, ()->{
                 Node patchLastIdNode = null;
-                Version patchLastVersion = Version.UNSET;
+                Version patchLastVersion = currentVersion;
 
                 for ( long ver = minVersion ; ver <= maxVersion ; ver++ ) {
                     //FmtLog.debug(LOG, "Play: patch=%s", ver);
@@ -438,9 +448,11 @@ public class DeltaConnection implements AutoCloseable {
                     try {
                         patch = dLink.fetch(datasourceId, verObj);
                         if ( patch == null ) {
-                            base.commit();
+                            // No patch. Patches have no gaps.
+                            // But a storage like S3 is only eventually consistent so stop
+                            // now and resync next time.
                             FmtLog.info(LOG, "Play: %s patch=%s : not found", datasourceId, verObj);
-                            continue;
+                            break;
                         }
                     } catch (DeltaNotFoundException ex) {
                         // Which ever way it is signalled.  This way means "bad datasourceId"

--- a/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/TestDeltaAssembler.java
+++ b/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/TestDeltaAssembler.java
@@ -27,7 +27,6 @@ import java.net.BindException;
 
 import org.apache.jena.assembler.exceptions.AssemblerException;
 import org.apache.jena.atlas.lib.FileOps;
-import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;

--- a/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/TestDeltaAssembler.java
+++ b/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/TestDeltaAssembler.java
@@ -27,6 +27,7 @@ import java.net.BindException;
 
 import org.apache.jena.assembler.exceptions.AssemblerException;
 import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
@@ -72,6 +73,7 @@ public class TestDeltaAssembler {
         FileOps.clearAll("target/Zone1");
         FileOps.clearAll("target/Zone2");
     }
+
     @Before public void before() throws BindException {
         LocalServerConfig config = LocalServers.configMem();
         LocalServer localServer = LocalServer.create(config);
@@ -83,6 +85,7 @@ public class TestDeltaAssembler {
 
     @After public void after() {
         deltaServer.stop();
+        Zone.clearZoneCache();
     }
 
     @Test public void assembler_delta_1() {
@@ -93,14 +96,39 @@ public class TestDeltaAssembler {
         assertNotNull(dataset.getContext().get(symDeltaClient));
     }
 
+    /*
+     * Sequence: second test fails if DeltaConnection.TestModeNoAsync = false;
+     * assembler_delta_2
+     * assembler_delta_3
+     * assembler_ext_good_1
+     * assembler_ext_good_2
+     */
+
+    private static void protect(Runnable r) {
+        boolean value = DeltaConnection.TestModeNoAsync;
+        DeltaConnection.TestModeNoAsync = true;
+        // Or it needs a long time (5 seconds) to finish cleanup.
+        // Lib.sleep(5000);
+        try {
+            r.run();
+        } finally {
+            DeltaConnection.TestModeNoAsync = value;
+        }
+    }
+
     @Test public void assembler_delta_2() {
+        protect(this::assembler_delta_2_work);
+    }
+
+    private void assembler_delta_2_work() {
         // TDB1
         Quad q1 = SSE.parseQuad("(:g :s :p 1)");
         Quad q2 = SSE.parseQuad("(:g :s :p 2)");
         {
             Dataset dataset = (Dataset)AssemblerUtils.build(DIR+"/delta-dataset-tdb1.ttl", DatasetAssembler.getType());
-            try ( DeltaConnection conn = connection(dataset) ) {
-                Txn.executeWrite(conn.getDatasetGraph(), ()->conn.getDatasetGraph().add(q1));
+            try ( DeltaConnection conn = connectionForDataset(dataset) ) {
+                dataset.executeWrite(()->conn.getDatasetGraph().add(q1));
+                dataset.executeRead(()->conn.getDatasetGraph().contains(q1));
             }
             Zone zone = (Zone)(dataset.getContext().get(symDeltaZone));
         }
@@ -108,20 +136,26 @@ public class TestDeltaAssembler {
         // Build again.
         {
             Dataset dataset = (Dataset)AssemblerUtils.build(DIR+"/delta-dataset-tdb1.ttl", DatasetAssembler.getType());
-            try ( DeltaConnection conn = connection(dataset) ) {
-                Txn.executeRead(conn.getDatasetGraph(), ()->assertTrue(conn.getDatasetGraph().contains(q1)));
+            try ( DeltaConnection conn = connectionForDataset(dataset) ) {
+                dataset.executeWrite(()->assertTrue(conn.getDatasetGraph().contains(q1)));
             }
         }
     }
 
     @Test public void assembler_delta_3() {
+        protect(this::assembler_delta_3_work);
+    }
+
+    private void assembler_delta_3_work() {
         // TDB2
         Quad q1 = SSE.parseQuad("(:g :s :p 1)");
         Quad q2 = SSE.parseQuad("(:g :s :p 2)");
         {
+            // If not protected and second run, fails here.
             Dataset dataset = (Dataset)AssemblerUtils.build(DIR+"/delta-dataset-tdb2.ttl", DatasetAssembler.getType());
-            try ( DeltaConnection conn = connection(dataset) ) {
-                Txn.executeWrite(conn.getDatasetGraph(), ()->conn.getDatasetGraph().add(q1));
+            try ( DeltaConnection conn = connectionForDataset(dataset) ) {
+                dataset.executeWrite(()->conn.getDatasetGraph().add(q1));
+                dataset.executeRead(()->conn.getDatasetGraph().contains(q1));
             }
             Zone zone = (Zone)(dataset.getContext().get(symDeltaZone));
         }
@@ -131,13 +165,13 @@ public class TestDeltaAssembler {
         // Build again.
         {
             Dataset dataset = (Dataset)AssemblerUtils.build(DIR+"/delta-dataset-tdb2.ttl", DatasetAssembler.getType());
-            try ( DeltaConnection conn = connection(dataset) ) {
-                Txn.executeRead(conn.getDatasetGraph(), ()->assertTrue(conn.getDatasetGraph().contains(q1)));
+            try ( DeltaConnection conn = connectionForDataset(dataset) ) {
+                dataset.executeWrite(()->assertTrue(conn.getDatasetGraph().contains(q1)));
             }
         }
     }
 
-    private static DeltaConnection connection(Dataset dataset) {
+    private static DeltaConnection connectionForDataset(Dataset dataset) {
         return (DeltaConnection)(dataset.getContext().get(symDeltaConnection));
     }
 
@@ -146,12 +180,25 @@ public class TestDeltaAssembler {
     //Need two zones? Windows-isms?
 
     @Test public void assembler_ext_good_1() {
+        protect(this::assembler_ext_good_1_work);
+    }
+
+    private void assembler_ext_good_1_work() {
         Dataset dataset = (Dataset)AssemblerUtils.build(DIR+"/delta-assembler-ext-good-1.ttl", VocabDelta.tDatasetDelta);
-        // @@ Use it.
+        try ( DeltaConnection conn = connectionForDataset(dataset) ) {
+            dataset.executeRead(()->assertTrue(conn.getDatasetGraph().isEmpty()));
+        }
     }
 
     @Test public void assembler_ext_good_2() {
+        protect(this::assembler_ext_good_2_work);
+    }
+
+    private void assembler_ext_good_2_work() {
         Dataset dataset = (Dataset)AssemblerUtils.build(DIR+"/delta-assembler-ext-good-2.ttl", VocabDelta.tDatasetDelta);
+        try ( DeltaConnection conn = connectionForDataset(dataset) ) {
+            Txn.executeRead(conn.getDatasetGraph(), ()->assertTrue(conn.getDatasetGraph().isEmpty()));
+        }
     }
 
     @Test(expected = AssemblerException.class)
@@ -168,11 +215,7 @@ public class TestDeltaAssembler {
 
     @Test(expected = AssemblerException.class)
     public void assembler_ext_bad_3() {
-        //
+        // delta:storage = "external" but no delta:dataset.
         Dataset dataset = (Dataset)AssemblerUtils.build(DIR+"/delta-assembler-ext-bad-3.ttl", VocabDelta.tDatasetDelta);
     }
-
-    // XXX External bad1 - :storage!=external
-    // XXX External bad2 - no :storage, no :dataset
-
 }


### PR DESCRIPTION
Included in background sync of on start-up is a recurring sync every 5 minutes. This helps with servers that are not receiving requests e.g. a front-facing load balancer has been routing all requests to another server (sticky routing).