### PR TITLE
close Streams returned from Files.list(Path)

### DIFF
--- a/rdf-delta-client/src/main/java/org/seaborne/delta/client/Zone.java
+++ b/rdf-delta-client/src/main/java/org/seaborne/delta/client/Zone.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern ;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.atlas.lib.NotImplemented ;
@@ -433,8 +434,8 @@ public class Zone {
      */
     private static List<Path> scanForDataState(Location workarea) {
         Path dir = IOX.asPath(workarea);
-        try {
-            List<Path> datasources = Files.list(dir)
+        try (Stream<Path> paths = Files.list(dir)) {
+            List<Path> datasources = paths
                 .filter(p->Files.isDirectory(p))
                 // Not deleted and moved aside.
                 .filter(p->!isDeleted(p))

--- a/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/patchstores/filestore/FileArea.java
+++ b/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/patchstores/filestore/FileArea.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.jena.atlas.json.JSON;
 import org.apache.jena.atlas.json.JsonObject;
@@ -84,8 +85,8 @@ public class FileArea {
      * May not be formatted properly.
      */
     private static Pair<List<Path>/*enabled*/, List<Path>/*disabled*/> scanDirectory(Path directory) {
-        try {
-            List<Path> directoryEntries = ListUtils.toList( Files.list(directory).filter(p->Files.isDirectory(p)).sorted() );
+        try (Stream<Path> paths = Files.list(directory)) {
+            List<Path> directoryEntries = ListUtils.toList( paths.filter(p->Files.isDirectory(p)).sorted() );
             List<Path> enabled = directoryEntries.stream()
                 .filter(path -> isEnabled(path))
                 .collect(Collectors.toList());


### PR DESCRIPTION
Although I have not encountered any problems with these streams, they can cause problems, esp, on Windows. The Javadoc for `Files.list(Path)` says "`This method must be used within a try-with-resources statement or similar control structure...`".