### PR TITLE
fix a few logging typos

### DIFF
--- a/rdf-delta-client/src/main/java/org/seaborne/delta/client/DeltaConnection.java
+++ b/rdf-delta-client/src/main/java/org/seaborne/delta/client/DeltaConnection.java
@@ -467,7 +467,7 @@ public class DeltaConnection implements AutoCloseable {
                 return Pair.create(patchLastVersion, patchLastIdNode);
             });
         } catch (Throwable th) {
-            FmtLog.warn(LOG, "Play: Problem for %s", datasourceId, th);
+            FmtLog.warn(LOG, th, "Play: Problem for %s", datasourceId);
             throw th;
         }
     }

--- a/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/patchstores/zk/PatchLogIndexZk.java
+++ b/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/patchstores/zk/PatchLogIndexZk.java
@@ -127,7 +127,7 @@ public class PatchLogIndexZk implements PatchLogIndex {
                 long ver = x.stream().map(this::versionFromName).filter(v->(v>0)).min(Long::compare).orElseThrow();
                 earliestVersion = Version.create(ver);
             } catch (NoSuchElementException ex) {
-                FmtLog.warn(LOG, "Failed to find the earliest value when thee is at least one version");
+                FmtLog.warn(LOG, "Failed to find the earliest value when there is at least one version");
             }
         }
         earliestId = versionToId(earliestVersion);
@@ -337,7 +337,7 @@ public class PatchLogIndexZk implements PatchLogIndex {
             Id newPrevious = entry.getPrevious();
             newState(ver, newCurrent, newPrevious);
         } catch (RuntimeException ex) {
-            FmtLog.error(this.getClass(), "Failed to load the patch log index state", ex);
+            FmtLog.error(this.getClass(), ex, "Failed to load the patch log index state");
         }
     }
 


### PR DESCRIPTION
When researching some problems, I came across a couple of bits of logging code that seemed to want to log a stack trace, but put the exception in the string format var-args and the exception was then ignored.